### PR TITLE
fix: align license update handling with online launch mode

### DIFF
--- a/maxima-lib/src/core/launch.rs
+++ b/maxima-lib/src/core/launch.rs
@@ -277,7 +277,10 @@ pub async fn start_game(
         }
         LaunchMode::OnlineOffline(_, ref persona, ref password) => {
             let auth = LicenseAuth::Direct(persona.to_owned(), password.to_owned());
-            request_and_save_license(&auth, &content_id, path.to_owned().into()).await?;
+
+            if needs_license_update(&content_id).await? {
+                request_and_save_license(&auth, &content_id, path.to_owned().into()).await?;
+            }
         }
     }
 

--- a/maxima-lib/src/core/launch.rs
+++ b/maxima-lib/src/core/launch.rs
@@ -280,6 +280,8 @@ pub async fn start_game(
 
             if needs_license_update(&content_id).await? {
                 request_and_save_license(&auth, &content_id, path.to_owned().into()).await?;
+            } else {
+                info!("Existing game license is still valid, not updating");
             }
         }
     }


### PR DESCRIPTION
Apply the same license update check used in online mode to online/offline launches