### PR TITLE
Don't reject external LSX connections

### DIFF
--- a/maxima-lib/src/lsx/connection.rs
+++ b/maxima-lib/src/lsx/connection.rs
@@ -209,48 +209,49 @@ impl Connection {
         stream.set_nonblocking(true)?;
         stream.set_read_timeout(Some(Duration::from_secs(1)))?;
 
+        let mut pid: Result<u32, NativeError> = Ok(0);
+
         let maxima: MutexGuard<'_, Maxima> = maxima_arc.lock().await;
-        let context: &ActiveGameContext = match maxima.playing() {
-            Some(context) => context,
+        match maxima.playing() {
             None => {
-                stream.shutdown(std::net::Shutdown::Both)?;
-                return Err(LSXConnectionError::GameContext);
-            }
-        };
+                warn!("External LSX connection (the game was not started through Maxima)");
+            },
+            Some(context) => {
+                // The PID system is mainly for Kyber injection
+                pid = get_os_pid(context);
+                if cfg!(unix) {
+                    if let Ok(os_pid) = pid {
+                        let sys = System::new_all();
+                        if let Some(process) = sys.process(Pid::from_u32(os_pid)) {
+                            let filename = PathBuf::from(
+                                process.cmd()[0]
+                                    .to_owned()
+                                    .replace("Z:", "")
+                                    .replace('\\', "/"),
+                            )
+                            .file_name()
+                            .ok_or(NativeError::FileName)?
+                            .to_str()
+                            .ok_or(NativeError::Stringify)?
+                            .to_owned();
 
-        // The PID system is mainly for Kyber injection
-        let mut pid = get_os_pid(context);
-        if cfg!(unix) {
-            if let Ok(os_pid) = pid {
-                let sys = System::new_all();
-                if let Some(process) = sys.process(Pid::from_u32(os_pid)) {
-                    let filename = PathBuf::from(
-                        process.cmd()[0]
-                            .to_owned()
-                            .replace("Z:", "")
-                            .replace('\\', "/"),
-                    )
-                    .file_name()
-                    .ok_or(NativeError::FileName)?
-                    .to_str()
-                    .ok_or(NativeError::Stringify)?
-                    .to_owned();
-
-                    pid = get_wine_pid(&context.launch_id(), &filename).await;
-                } else {
-                    warn!(
-                        "Failed to find game process while looking for PID {}",
-                        os_pid
-                    );
+                            pid = get_wine_pid(&context.launch_id(), &filename).await;
+                        } else {
+                            warn!(
+                                "Failed to find game process while looking for PID {}",
+                                os_pid
+                            );
+                        }
+                    }
                 }
-            }
-        }
 
-        if let Err(ref err) = pid {
-            warn!("Error while finding game PID: {}", err);
-        } else if pid.as_ref().unwrap() == &0 {
-            warn!("Failed to find PID through launch ID, things may not work!");
-        }
+                if let Err(ref err) = pid {
+                    warn!("Error while finding game PID: {}", err);
+                } else if pid.as_ref().unwrap() == &0 {
+                    warn!("Failed to find PID through launch ID, things may not work!");
+                }
+            },
+        };
 
         let state = Arc::new(RwLock::new(ConnectionState {
             maxima: maxima_arc.clone(),


### PR DESCRIPTION
This is a simple change to allow external LSX connections to be accepted. This works, though Maxima doesn't show the player state as in-game and I have no idea how this affects presence.

Why? Because the user might have external WINE prefix with a working game installation (it requires some mods to game), and LSX is just a TCP server. Personally for me launching games with Maxima doesn't seem to work at all currently, so this makes the difference between being able to use it at all or not... (this will work out of the box with Titanfall with my Black Market Edition mod in its next version)

The PR just makes the code not drop the connection if `maxima.playing` isn't populated, moving the PID grabbing code to conditionally happen only if it is.

```
INFO - [maxima::lsx::service] - New LSX connection: 127.0.0.1:47146
WARN - [maxima::lsx::connection] - External LSX connection (the game was not started through Maxima)
INFO - [maxima::lsx::request::challenge] - Game Connected - Name: Titanfall, Offer ID: 1011172, Multiplayer Id: 1011172
INFO - [maxima::lsx::request::auth] - Retrieving authorization code for 'TITANFALL'
```